### PR TITLE
Add support for posting to Keybase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # AdventOfCodeSlackbot
-Slackbot to notify when someone on the leaderboard has achieved a new star
+Slackbot/Keybasebot to notify when someone on the leaderboard has achieved a new star
 
 # About
 This project was built with Swift Package Manager with Swift 4 and generally followed this tutorial: 
 <https://www.swiftbysundell.com/posts/building-a-command-line-tool-using-the-swift-package-manager>
+
+# Environment Variables
+
+A webhook URL must be set with one of these two environment variables:
+`WEBHOOK`: Webhook URL for posting to Slack/Keybase.
+`WEBHOOK_TYPE`: Which service will be receiving the webhook, should be `slack` or `keybase`. If unset, defaults to `slack`.
+`ADVENT_COOKIE`: Advent-of-Code web cookie for authentication.
+`ADVENT_JSON`: JSON URL for retrieving the leaderboard to monitor.
 
 # Generating Xcode Project
 `swift package generate-xcodeproj`


### PR DESCRIPTION
### What
Add support for posting to Keybase via the [Keybase Webhook Bot].

### Why
So that this bot can be used with either Slack or Keybase.

[Keybase Webhook Bot]: https://keybase.io/webhookbot